### PR TITLE
Use correct index in dimer function

### DIFF
--- a/single.c
+++ b/single.c
@@ -2589,7 +2589,7 @@ int dimer(char primer[],int length)
 	}
 	else
 	{
-		if(primer[length-1]!='C')
+		if(primer[length-6]!='C')
 			return 1;
 	}
 


### PR DESCRIPTION
I think the dimer function uses the wrong index in one case. The code checks if `primer[length-1]` is A, T or C in lines 2575, 2580 and 2585 respectively. That means in the `else` branch starting at line 2590, we can assume that `primer[length-1]` is G. As far as I can tell, inside the else branch, knowing that `primer[length-1] == 'G'`, we should check `primer[length-6] != 'C'` instead. That seems also more consistent with the rest of the function.